### PR TITLE
Various fixes and improvements

### DIFF
--- a/CloudScraper.py
+++ b/CloudScraper.py
@@ -45,7 +45,7 @@ def start(target):
     print(colored("Beginning search for cloud resources in {}".format(target), color='cyan'))
 
     try:
-        html = requests.get(target, allow_redirects=True, headers=headers).text
+        html = requests.get(target, allow_redirects=True, headers=headers, verify=False).text
         links = gather_links(html)
 
     except requests.exceptions.RequestException as e:
@@ -65,7 +65,7 @@ def worker(url):
     '''
     if url.count("/") <= arguments.depth+2:
         try:
-            html = requests.get(url, allow_redirects=True, headers=headers).text
+            html = requests.get(url, allow_redirects=True, headers=headers, verify=False).text
             links = gather_links(html)
 
         except requests.exceptions.RequestException as e:
@@ -121,6 +121,9 @@ def spider(base_urls, target):
         
         print(colored('\nNew urls appended: {}\n'.format(i), 'green', attrs=['bold']))
 
+    p.close()
+    p.join()
+
     #once all the links for the given depth have been analyzed, execute the parser
     parser(base_urls)
 
@@ -165,9 +168,9 @@ def args():
 
 def cleaner(url):
     if 'http' not in url:
-        return ("https://"+url).rstrip()
+        return ("https://"+url).strip()
     else:
-        return url
+        return url.strip()
 
 
 def main():
@@ -178,7 +181,9 @@ def main():
         start(cleaner(arguments.URL))
 
 
-headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'}
+headers = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36'
+}
 arguments = args()
 
 if __name__ == '__main__':

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python
+
+WORKDIR /usr/src/CloudScraper
+
+COPY ./requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
+
+COPY ./ ./
+ENTRYPOINT ["python3", "/usr/src/CloudScraper/CloudScraper.py"]
+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ This tool was inspired by a recent talk by [Bryce Kunz](https://twitter.com/Twee
       -d DEPTH       Max Depth of links Default: 5
       -l TARGETLIST  Location of text file of Line Delimited targets
       -v Verbose     Verbose output
-      -p Processes  Number of processes to be executed in parallel. Default: 2
+      -p Processes   Number of processes to be executed in parallel. Default: 2
+      --no-verify    Skip TLS verification
 
     example: python3 CloudScraper.py -u https://rottentomatoes.com
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 rfc3987
 termcolor
-requests==2.20.0
+requests
 BeautifulSoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ rfc3987
 termcolor
 requests
 BeautifulSoup4
+urllib3


### PR DESCRIPTION
I forked this some time ago (at https://github.com/RhinoSecurityLabs/CloudScraper) because I was running into issues on the latest commit here. I happened to check my fork just now and noticed some people have been using it and have even got a PR to add more domains to check.

I'd rather not maintain a fork though so wanted to push the changes upstream if possible.

* Resolve #9 
* Add --no-verify flag for skipping TLS verification.
  * Sites with broken TLS can still be useful so failing in these cases isn't always beneficial (I suspect most the time it's not, but didn't want to make this assumption so throwing this behind a flag for now).
* Always strip extra whitespace from the URL.
  * Previously this only stripped extra chars on the right when the link did not contain `http` which (iirc) caused issues in some cases.
* Update user agent.
  * I don't remember what the issue here was but iirc some site was acting up with the user agent that was set before.